### PR TITLE
Do not check CRC on non-exiting file

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,7 +3,7 @@ skip_commits:
     - '**/*.md'
     - '.vscode/**/*'
 cache:
-  - '%USERPROFILE%\Documents\WindowsPowerShell\Modules -> appveyor.yml'
+  - '%USERPROFILE%\Documents\WindowsPowerShell\Modules -> .appveyor.yml'
 matrix:
   fast_finish: true
 build: 'off'


### PR DESCRIPTION
Issue: https://help.appveyor.com/discussions/problems/22552-deployments-keep-failing-the-first-time
Side effect of checking CRC on non-exiting file is creation of that file with zero size.
