### PR TITLE
Add Lav Filters Megamix

### DIFF
--- a/bucket/lav-filters-megamix.json
+++ b/bucket/lav-filters-megamix.json
@@ -1,0 +1,40 @@
+{
+	"version": "0.74.1-30",
+	"homepage": "https://www.videohelp.com/software/LAV-Filters-Megamix",
+	"description": "LAV Filters Megamix is a codec pack containing madVR,LAV Filters,ASSFilterMod,XySubFilter(disabled by default),xy-vsfilter(disabled by default) and Reclock(only in 32-bit) with video players like MPC-HC,MPDN and Potplayer",
+	"license": "Freeware",
+    "architecture": {
+        "64bit": {
+            "url": "https://www.videohelp.com/download/Megamix-LAVFilters-0.74.1-30-x64.exe#/LAVFiltersMegamix-setup.exe",
+            "hash": "772cd1ff1738d4b00210dc6e5ef6672aede0f8f67812a424196ef24c8b457fd4"
+        },
+        "32bit": {
+            "url": "https://www.videohelp.com/download/Megamix-LAVFilters-0.74.1-30-x86.exe#/LAVFiltersMegamix-setup.exe",
+            "hash": "8cbe4d0b9e7b3f4ceb4712aedee65ed7f969f833d682c67dc13a6097b48f4015"
+        }
+    },
+	"depends": "Ash258/DirectX",
+	"installer": {
+        "file": "LAVFiltersMegamix-setup.exe",
+        "args": [
+            "/dir=$dir"
+        ]
+	},
+	 "uninstaller": {
+        "file": "unins000.exe"
+	    },
+	"checkver": {
+		"url": "https://www.videohelp.com/software/LAV-Filters-Megamix",
+		"regex": "Latest version.*\\s+([\\d-.]+)"
+	},
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "ttps://www.videohelp.com/download/Megamix-LAVFilters-$version-x64.exe#/LAVFiltersMegamix-setup.exe"
+            },
+            "32bit": {
+                "url": "https://www.videohelp.com/download/Megamix-LAVFilters-$version-x86.exe#/LAVFiltersMegamix-setup.exe"
+                      }
+	   }
+     }
+}


### PR DESCRIPTION
Successor of Kawaii Codec Pack. The one in scoop-nonportable just installs MPDN. The proper way to install this is to launch the installer itself.